### PR TITLE
Preventing doubleclicks on form submits

### DIFF
--- a/ledger/static/ledger/utils.js
+++ b/ledger/static/ledger/utils.js
@@ -120,7 +120,7 @@ updateTabs = (dateFrom, dateTo, reimbursed, payed, outstanding) =>{
                                 ${trans.receiver}
                             </td>
                             <td class="text-end">${each.amount}</td>
-                            <td>${resolveBtnHTML}</td>
+                            <td class="text-center">${resolveBtnHTML}</td>
                         </tr>`        
                 }
             }

--- a/ledger/templates/ledger/create-acc.html
+++ b/ledger/templates/ledger/create-acc.html
@@ -127,6 +127,7 @@ $(()=>{
             let otherJson = JSON.stringify(otherParties)
             $('#otherPartyPost').val(otherJson)
             $('#newAccForm').submit()
+            accBtn.attr('disabled', true);
         }
         else{
             alert('Their balance value must be a positive number with 2 decimal places.')

--- a/ledger/templates/ledger/create-cli-acc.html
+++ b/ledger/templates/ledger/create-cli-acc.html
@@ -65,9 +65,14 @@
                 }
             })
             if (filled){
-                subBtn.attr('disabled', false)
+                subBtn.attr('disabled', false);
             } else{
-                subBtn.attr('disabled', true)
+                subBtn.attr('disabled', true);
+            }
+        })
+        subBtn.click(()=>{
+            if (!subBtn.attr('disabled')){
+                subBtn.attr('disabled', true);
             }
         })
     })

--- a/ledger/templates/ledger/create-off-acc.html
+++ b/ledger/templates/ledger/create-off-acc.html
@@ -72,6 +72,7 @@
             let balVal = $('#balanceInput').val()
             if (/^\d+\.\d{2}$/.test(balVal)){
                 $('#newOffAccForm').submit()
+                subBtn.attr('disabled', true);
             } else{
                 alert('The balance value must be a positive number with 2 decimal places.');
             }

--- a/ledger/templates/ledger/office.html
+++ b/ledger/templates/ledger/office.html
@@ -113,7 +113,7 @@
                                             <input type="hidden" name="trans_id" value="{{trans.id}}">
                                             <input type="hidden" name="acc_id" value="{{off_acc.id}}">
                                             <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                                            <button type="submit" class="btn btn-primary">Confirm Removal</button>
+                                            <button type="submit" class="btn btn-primary" id="counterBtn">Confirm Removal</button>
                                         </form>
                                     </div>
                                 </div>
@@ -242,6 +242,9 @@
             let transID = checkInp.attr('data-id');
             let offID = checkInp.attr('data-off');
             $.post( "{% url 'ledger:show_off' %}", {checked:e.target.checked, off_id:offID, trans_id:transID, form_type:'checkbox'});
+        })
+        $('#counterBtn').click(()=>{
+            $('#counterBtn').attr('disabled', true);
         })
     })
 </script>

--- a/ledger/templates/ledger/resolve.html
+++ b/ledger/templates/ledger/resolve.html
@@ -38,7 +38,7 @@
                 <input type="hidden" name="off_trans_id" id=""  value="{{off_trans.id}}">
                 <input type="hidden" name="off_acc_id" value="{{off_acc.id}}">
                 <input type="hidden" name="acc_id" value="{{acc.id}}">
-                <summary>This transaction will debit the aforementioned client file({{acc.client_code}}) whilst crediting the stated office account.</summary>
+                <summary>This transaction will debit the aforementioned client file ({{acc.client_code}}) whilst crediting the stated office account.</summary>
                 <div class="text-end">
                     <a href="{% url 'ledger:adat_index' %}" class="btn btn-secondary">Cancel</a>
                     <button id='transBtn' type='submit' class="btn btn-primary">Confirm</button>
@@ -49,4 +49,12 @@
         </div>
     </div>
 </div>
+
+<script>
+    $(()=>{
+        $('#transBtn').click(()=>{
+            $('#transBtn').attr('disabled', true);
+        })
+    })
+</script>
 {% endblock %}

--- a/ledger/templates/ledger/show-acc.html
+++ b/ledger/templates/ledger/show-acc.html
@@ -259,7 +259,7 @@
                                         <input type="hidden" name="trans_id" value="{{trans.id}}">
                                         <input type="hidden" name="acc_id" value="{{account.id}}">
                                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-                                        <button type="submit" class="btn btn-primary">Confirm Removal</button>
+                                        <button type="submit" class="btn btn-primary" id="counterBtn">Confirm Removal</button>
                                     </form>
                                     
                                 </div>
@@ -412,6 +412,9 @@
     </div>
 <script charset="utf-8">
 $(()=>{
+    $('#counterBtn').click(()=>{
+        $('#counterBtn').attr('disabled', true);
+    })
     $('.transRow').dblclick((e)=>{
         id = $(e.currentTarget).attr('data-id');
         $(`#a${id}`)[0].click()

--- a/ledger/templates/ledger/transaction.html
+++ b/ledger/templates/ledger/transaction.html
@@ -133,7 +133,11 @@
                 <br>
                 <div class="d-flex justify-content-between">
                     <button id='transBtn' disabled type='button' class="btn btn-primary">Confirm</button>
+                    {% if account.is_office %}
+                    <a class="btn btn-secondary" href="{% url 'ledger:show_off' %}">Back to Account</a>
+                    {% else %}
                     <a class="btn btn-secondary" href="{% url 'ledger:show_acc' account.id %}">Back to Account</a>
+                    {%endif%}
                 </div>
             </form>
         </div>
@@ -496,6 +500,7 @@ $(()=>{
             $('#tableData').val(JSON.stringify(tableData));
             $('#totalInp').val(amountCheck().toFixed(2))
             $('#transForm').submit();
+            transBtn.attr('disabled', true);
         }
     })
 })

--- a/todo.txt
+++ b/todo.txt
@@ -1,5 +1,8 @@
-!! double check on transactions not showing on transaction ledger.
+!! double check on transactions not showing on transaction ledger. - office account receiving transactions not working??
 
+!Transaction cancellation not pulling the ID correctly.
+
+read this "// ajax for checkbox updating server." in office html.
 
 !create separate client accounts and allow viewing of each independently. - links to individual accs from this page
 !transaction page for client account.
@@ -12,6 +15,8 @@ ask what to be in cheque text, for AT and the auto credit
 ask what does she want in the ref no. column for reimbursed AD
 
 warn user if client file no is duplicate
+
+Find a way to select radio for office acc viewing upon clicking back, etc.
 
 make all datepickers use dd/mm/yyyy format
 make date times tz aware


### PR DESCRIPTION
Preventing double submissions by using js on client side to disable buttons after submission criteria met & btn clicked.

Centering "Yes" on clearing AD on adat-index.